### PR TITLE
Added new features

### DIFF
--- a/MedikTapp.Android/MainActivity.cs
+++ b/MedikTapp.Android/MainActivity.cs
@@ -8,6 +8,8 @@ using MedikTapp.DI;
 using MedikTapp.Droid.Implementations;
 using MedikTapp.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
+using Plugin.LocalNotification;
+using Plugin.LocalNotification.Platform.Droid;
 using Rg.Plugins.Popup;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
@@ -50,7 +52,8 @@ namespace MedikTapp.Droid
 
         private static void AddPlatformSpecificServices(IServiceCollection services)
         {
-            services.AddSingleton<IToast, ToastDroid>();
+            services.AddSingleton<IToast, ToastDroid>()
+                .AddSingleton<INotificationService, NotificationServiceImpl>();
         }
 
         private void SetStatusBarColor()

--- a/MedikTapp/Helpers/DataTemplateSelector/ScheduleDataTemplateSelector.cs
+++ b/MedikTapp/Helpers/DataTemplateSelector/ScheduleDataTemplateSelector.cs
@@ -1,0 +1,18 @@
+﻿using MedikTapp.Enums;
+using Xamarin.Forms;
+
+namespace MedikTapp.Helpers.DataTemplateSelector
+{
+    public class ScheduleDataTemplateSelector : Xamarin.Forms.DataTemplateSelector
+    {
+        public DataTemplate CancelledTemplate { get; set; }
+        public DataTemplate NotCancelledTemplate { get; set; }
+
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+        {
+            return ((Models.Services)item).BookingStatus == BookingStatus.Cancelled
+                ? CancelledTemplate
+                : NotCancelledTemplate;
+        }
+    }
+}

--- a/MedikTapp/Services/NotificationService/NotificationService.cs
+++ b/MedikTapp/Services/NotificationService/NotificationService.cs
@@ -11,20 +11,21 @@ namespace MedikTapp.Services.NotificationService
     public class NotificationService
     {
         private readonly IEnumerable<INotificationActionTapped> _actionTapped;
-
-        public NotificationService(IEnumerable<INotificationActionTapped> actionTapped)
+        private readonly INotificationService _notificationService;
+        public NotificationService(IEnumerable<INotificationActionTapped> actionTapped, INotificationService notificationService)
         {
             _actionTapped = actionTapped;
+            _notificationService = notificationService;
         }
 
         public void CancelByNotificationIds(params int[] notificationIdList)
-            => NotificationCenter.Current.Cancel(notificationIdList);
+            => _notificationService.Cancel(notificationIdList);
 
-        public void CancelAll() => NotificationCenter.Current.CancelAll();
+        public void CancelAll() => _notificationService.CancelAll();
 
-        public static void RegisterCategory(HashSet<NotificationCategory> categories)
+        public void RegisterCategory(HashSet<NotificationCategory> categories)
         {
-            NotificationCenter.Current.RegisterCategoryList(categories);
+            _notificationService.RegisterCategoryList(categories);
         }
 
         public Task Send(int notificationId, string title, DateTime notificationTime, string description = null,
@@ -39,7 +40,7 @@ namespace MedikTapp.Services.NotificationService
                 notificationRepeatInterval :
                 null;
 
-            return NotificationCenter.Current.Show((notification) =>
+            return _notificationService.Show((notification) =>
             {
                 notification.WithNotificationId(notificationId)
                 .WithTitle(title)
@@ -75,22 +76,5 @@ namespace MedikTapp.Services.NotificationService
 
             _actionTapped.FirstOrDefault(s => s.ActionId == e.ActionId)?.Execute(e);
         }
-
-        //public Task Send(string description, DateTime trigger)
-        //{
-        //    return Send(69420, "MedikTapp", trigger, description, categoryType: NotificationCategoryType.Recommendation,
-        //        androidSpecificOptions: new AndroidOptions
-        //        {
-        //            Group = "MedikTapp",
-        //            IsGroupSummary = true,
-        //            Priority = AndroidNotificationPriority.Max,
-        //            VisibilityType = AndroidVisibilityType.Public,
-        //        },
-        //        androidScheduleOptions: new AndroidScheduleOptions
-        //        {
-        //            AlarmType = AndroidAlarmType.RtcWakeup,
-        //            AllowedDelay = TimeSpan.FromSeconds(30)
-        //        });
-        //}
     }
 }

--- a/MedikTapp/Views/Welcome/Main/Schedule/ScheduleTab.xaml
+++ b/MedikTapp/Views/Welcome/Main/Schedule/ScheduleTab.xaml
@@ -3,6 +3,7 @@
                xmlns="http://xamarin.com/schemas/2014/forms"
                xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                xmlns:converter="clr-namespace:MedikTapp.Converters"
+               xmlns:dtSelector="clr-namespace:MedikTapp.Helpers.DataTemplateSelector"
                xmlns:enums="clr-namespace:MedikTapp.Enums"
                xmlns:fonts="clr-namespace:MedikTapp.Resources.Fonts"
                xmlns:helpers="clr-namespace:MedikTapp.Helpers"
@@ -59,6 +60,273 @@
             <Setter Property="HorizontalOptions" Value="Start" />
             <Setter Property="TextColor" Value="#2F2F32" />
         </Style>
+        <dtSelector:ScheduleDataTemplateSelector x:Key="ScheduleTemplateSelector">
+            <dtSelector:ScheduleDataTemplateSelector.CancelledTemplate>
+                <DataTemplate x:DataType="models:Services">
+                    <Frame Padding="10"
+                           BackgroundColor="White"
+                           HasShadow="True">
+                        <Grid helpers:Gestures.Tapped="{Binding ServiceTappedCmd, Source={x:Reference this}}"
+                              helpers:Gestures.TappedParameter="{Binding .}"
+                              ColumnDefinitions="*,100"
+                              RowDefinitions="80,65">
+                            <!--#region  Doc or Service Name, Doc Specialty, and Image-->
+                            <Label Grid.Row="0"
+                                   Grid.Column="0"
+                                   Grid.ColumnSpan="2"
+                                   FontFamily="med"
+                                   FontSize="20"
+                                   HorizontalOptions="StartAndExpand"
+                                   LineBreakMode="TailTruncation"
+                                   Text="{Binding ServiceName}"
+                                   TextColor="{StaticResource Black}"
+                                   VerticalOptions="Start"
+                                   WidthRequest="280" />
+
+                            <Label Grid.Row="0"
+                                   Grid.Column="0"
+                                   Grid.ColumnSpan="2"
+                                   Margin="0,20,0,0"
+                                   FontFamily="reg"
+                                   HorizontalOptions="StartAndExpand"
+                                   LineBreakMode="TailTruncation"
+                                   MaxLines="2"
+                                   Text="{Binding ServiceDescription}"
+                                   TextColor="Gray"
+                                   VerticalOptions="CenterAndExpand"
+                                   WidthRequest="280" />
+
+
+                            <templateImg:CachedImage Grid.Row="0"
+                                                     Grid.Column="1"
+                                                     HeightRequest="60"
+                                                     HorizontalOptions="End"
+                                                     ImageSource="{Binding ServiceImagePath}"
+                                                     VerticalOptions="Start"
+                                                     WidthRequest="60" />
+
+                            <BoxView Grid.Row="0"
+                                     Grid.Column="0"
+                                     Grid.ColumnSpan="2"
+                                     Margin="0,0,0,-7"
+                                     BackgroundColor="#F2F3F6"
+                                     HeightRequest=".7"
+                                     VerticalOptions="End" />
+                            <!--#endregion-->
+
+                            <!--#region Date, Time, Booking Status-->
+                            <Grid Grid.Row="1"
+                                  Grid.Column="0"
+                                  Grid.ColumnSpan="2"
+                                  Margin="0,10,0,10"
+                                  ColumnDefinitions="*,*,*">
+
+                                <!--#region Date-->
+                                <StackLayout Grid.Column="0"
+                                             HorizontalOptions="Center"
+                                             Orientation="Horizontal"
+                                             VerticalOptions="Center">
+                                    <Label Margin="0,0,0,5"
+                                           Style="{StaticResource ScheduleFontIcons}"
+                                           Text="{x:Static fonts:FontAwesomeIcons.CalendarDays}" />
+                                    <Label Style="{StaticResource ScheduleFontIconsDesc}"
+                                           Text="{Binding AvailableTime, StringFormat='{0: M/dd/yyy}'}" />
+                                </StackLayout>
+                                <!--#endregion-->
+
+                                <!--#region Time-->
+                                <StackLayout Grid.Column="1"
+                                             HorizontalOptions="Center"
+                                             Orientation="Horizontal"
+                                             VerticalOptions="Center">
+                                    <Label Margin="0,0,0,2"
+                                           Style="{StaticResource ScheduleFontIcons}"
+                                           Text="{x:Static fonts:FontAwesomeIcons.Clock}" />
+                                    <Label Style="{StaticResource ScheduleFontIconsDesc}"
+                                           Text="{Binding AvailableTime.TimeOfDay}" />
+                                </StackLayout>
+                                <!--#endregion-->
+
+                                <!--#region Booking Status-->
+                                <StackLayout Grid.Column="2"
+                                             HorizontalOptions="Center"
+                                             Orientation="Horizontal"
+                                             VerticalOptions="Center">
+                                    <Ellipse Fill="#00DC54"
+                                             HeightRequest="10"
+                                             HorizontalOptions="Start"
+                                             VerticalOptions="Center"
+                                             WidthRequest="10">
+                                        <Ellipse.Triggers>
+                                            <DataTrigger Binding="{Binding BookingStatus}"
+                                                         TargetType="Ellipse"
+                                                         Value="{x:Static enums:BookingStatus.Pending}">
+                                                <Setter Property="Fill" Value="#FF8E00" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding BookingStatus}"
+                                                         TargetType="Ellipse"
+                                                         Value="{x:Static enums:BookingStatus.Cancelled}">
+                                                <Setter Property="Fill" Value="#E63C3C" />
+                                            </DataTrigger>
+                                        </Ellipse.Triggers>
+                                    </Ellipse>
+                                    <Label Style="{StaticResource ScheduleFontIconsDesc}"
+                                           Text="{Binding BookingStatus}" />
+                                </StackLayout>
+                                <!--#endregion-->
+                            </Grid>
+                            <!--#endregion-->
+                        </Grid>
+                    </Frame>
+                </DataTemplate>
+            </dtSelector:ScheduleDataTemplateSelector.CancelledTemplate>
+            <dtSelector:ScheduleDataTemplateSelector.NotCancelledTemplate>
+                <DataTemplate x:DataType="models:Services">
+                    <Frame Padding="10"
+                           BackgroundColor="White"
+                           HasShadow="True">
+                        <Grid helpers:Gestures.Tapped="{Binding ServiceTappedCmd, Source={x:Reference this}}"
+                              helpers:Gestures.TappedParameter="{Binding .}"
+                              ColumnDefinitions="*,65"
+                              RowDefinitions="80,50,50">
+                            <!--#region  Doc or Service Name, Doc Specialty, and Image-->
+                            <Label Grid.Row="0"
+                                   Grid.Column="0"
+                                   Grid.ColumnSpan="2"
+                                   FontFamily="med"
+                                   FontSize="20"
+                                   HorizontalOptions="StartAndExpand"
+                                   LineBreakMode="TailTruncation"
+                                   Text="{Binding ServiceName}"
+                                   TextColor="{StaticResource Black}"
+                                   VerticalOptions="Start"
+                                   WidthRequest="280" />
+
+                            <Label Grid.Row="0"
+                                   Grid.Column="0"
+                                   Grid.ColumnSpan="2"
+                                   Margin="0,20,0,0"
+                                   FontFamily="reg"
+                                   HorizontalOptions="StartAndExpand"
+                                   LineBreakMode="TailTruncation"
+                                   MaxLines="2"
+                                   Text="{Binding ServiceDescription}"
+                                   TextColor="Gray"
+                                   VerticalOptions="CenterAndExpand"
+                                   WidthRequest="280" />
+
+
+                            <templateImg:CachedImage Grid.Row="0"
+                                                     Grid.Column="1"
+                                                     HeightRequest="60"
+                                                     HorizontalOptions="End"
+                                                     ImageSource="{Binding ServiceImagePath}"
+                                                     VerticalOptions="Start"
+                                                     WidthRequest="60" />
+
+                            <BoxView Grid.Row="0"
+                                     Grid.Column="0"
+                                     Grid.ColumnSpan="2"
+                                     Margin="0,0,0,-7"
+                                     BackgroundColor="#F2F3F6"
+                                     HeightRequest=".7"
+                                     VerticalOptions="End" />
+                            <!--#endregion-->
+
+                            <!--#region Date, Time, Booking Status-->
+                            <Grid Grid.Row="1"
+                                  Grid.Column="0"
+                                  Grid.ColumnSpan="2"
+                                  Margin="0,10,0,10"
+                                  ColumnDefinitions="*,*,*">
+
+                                <!--#region Date-->
+                                <StackLayout Grid.Column="0"
+                                             HorizontalOptions="Center"
+                                             Orientation="Horizontal"
+                                             VerticalOptions="Center">
+                                    <Label Margin="0,0,0,5"
+                                           Style="{StaticResource ScheduleFontIcons}"
+                                           Text="{x:Static fonts:FontAwesomeIcons.CalendarDays}" />
+                                    <Label Style="{StaticResource ScheduleFontIconsDesc}"
+                                           Text="{Binding AvailableTime, StringFormat='{0: M/dd/yyy}'}" />
+                                </StackLayout>
+                                <!--#endregion-->
+
+                                <!--#region Time-->
+                                <StackLayout Grid.Column="1"
+                                             HorizontalOptions="Center"
+                                             Orientation="Horizontal"
+                                             VerticalOptions="Center">
+                                    <Label Margin="0,0,0,2"
+                                           Style="{StaticResource ScheduleFontIcons}"
+                                           Text="{x:Static fonts:FontAwesomeIcons.Clock}" />
+                                    <Label Style="{StaticResource ScheduleFontIconsDesc}"
+                                           Text="{Binding AvailableTime.TimeOfDay}" />
+                                </StackLayout>
+                                <!--#endregion-->
+
+                                <!--#region Booking Status-->
+                                <StackLayout Grid.Column="2"
+                                             HorizontalOptions="Center"
+                                             Orientation="Horizontal"
+                                             VerticalOptions="Center">
+                                    <Ellipse Fill="#00DC54"
+                                             HeightRequest="10"
+                                             HorizontalOptions="Start"
+                                             VerticalOptions="Center"
+                                             WidthRequest="10">
+                                        <Ellipse.Triggers>
+                                            <DataTrigger Binding="{Binding BookingStatus}"
+                                                         TargetType="Ellipse"
+                                                         Value="{x:Static enums:BookingStatus.Pending}">
+                                                <Setter Property="Fill" Value="#FF8E00" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{Binding BookingStatus}"
+                                                         TargetType="Ellipse"
+                                                         Value="{x:Static enums:BookingStatus.Cancelled}">
+                                                <Setter Property="Fill" Value="#E63C3C" />
+                                            </DataTrigger>
+                                        </Ellipse.Triggers>
+                                    </Ellipse>
+                                    <Label Style="{StaticResource ScheduleFontIconsDesc}"
+                                           Text="{Binding BookingStatus}" />
+                                </StackLayout>
+                                <!--#endregion-->
+                            </Grid>
+
+                            <Grid Grid.Row="2"
+                                  Grid.Column="0"
+                                  Grid.ColumnSpan="2"
+                                  ColumnDefinitions="*,*">
+                                <Button Grid.Column="0"
+                                        Margin="5,0"
+                                        BackgroundColor="#F4F5F9"
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type vm:ScheduleTabViewModel}}, Path=CancelScheduleCmd}"
+                                        CommandParameter="{Binding .}"
+                                        CornerRadius="10"
+                                        FontFamily="med"
+                                        FontSize="12"
+                                        Text="Cancel"
+                                        TextColor="{StaticResource Black}" />
+
+                                <Button Grid.Column="1"
+                                        Margin="5,0"
+                                        BackgroundColor="{StaticResource DarkPurple}"
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type vm:ScheduleTabViewModel}}, Path=RescheduleCmd}"
+                                        CommandParameter="{Binding .}"
+                                        CornerRadius="10"
+                                        FontFamily="med"
+                                        FontSize="12"
+                                        Text="Reschedule"
+                                        TextColor="White" />
+                            </Grid>
+                            <!--#endregion-->
+                        </Grid>
+                    </Frame>
+                </DataTemplate>
+            </dtSelector:ScheduleDataTemplateSelector.NotCancelledTemplate>
+        </dtSelector:ScheduleDataTemplateSelector>
     </ContentView.Resources>
 
     <Grid ColumnDefinitions="*,*,*"
@@ -142,6 +410,7 @@
                         Grid.ColumnSpan="3"
                         Margin="0,60,0,0"
                         ItemSizingStrategy="MeasureAllItems"
+                        ItemTemplate="{StaticResource ScheduleTemplateSelector}"
                         ItemsSource="{Binding Schedules}">
             <CollectionView.EmptyView>
                 <Frame BackgroundColor="#FBFBFB">
@@ -156,136 +425,6 @@
                 <LinearItemsLayout ItemSpacing="15"
                                    Orientation="Vertical" />
             </CollectionView.ItemsLayout>
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="models:Services">
-                    <Frame Padding="10"
-                           BackgroundColor="White"
-                           HasShadow="True">
-                        <Grid helpers:Gestures.Tapped="{Binding BindingContext.ServiceTappedCmd, Source={x:Reference this}}"
-                              helpers:Gestures.TappedParameter="{Binding .}"
-                              ColumnDefinitions="*,*"
-                              RowDefinitions="80,50,50">
-                            <!--#region  Doc or Service Name, Doc Specialty, and Image-->
-                            <Label Grid.Row="0"
-                                   Grid.Column="0"
-                                   Grid.ColumnSpan="2"
-                                   FontFamily="med"
-                                   FontSize="20"
-                                   HorizontalOptions="StartAndExpand"
-                                   LineBreakMode="TailTruncation"
-                                   Text="{Binding ServiceName}"
-                                   TextColor="{StaticResource Black}"
-                                   VerticalOptions="Start"
-                                   WidthRequest="280" />
-
-                            <Label Grid.Row="0"
-                                   Grid.Column="0"
-                                   Grid.ColumnSpan="2"
-                                   Margin="0,20,0,0"
-                                   FontFamily="reg"
-                                   HorizontalOptions="StartAndExpand"
-                                   LineBreakMode="TailTruncation"
-                                   MaxLines="2"
-                                   Text="{Binding ServiceDescription}"
-                                   TextColor="Gray"
-                                   VerticalOptions="CenterAndExpand"
-                                   WidthRequest="280" />
-
-
-                            <templateImg:CachedImage Grid.Row="0"
-                                                     Grid.Column="1"
-                                                     HeightRequest="65"
-                                                     HorizontalOptions="End"
-                                                     ImageSource="{Binding ServiceImagePath}"
-                                                     VerticalOptions="Start"
-                                                     WidthRequest="65" />
-
-                            <BoxView Grid.Row="0"
-                                     Grid.Column="0"
-                                     Grid.ColumnSpan="2"
-                                     Margin="0,0,0,-7"
-                                     BackgroundColor="#F2F3F6"
-                                     HeightRequest=".7"
-                                     VerticalOptions="End" />
-                            <!--#endregion-->
-
-                            <!--#region Date, Time, Booking Status-->
-                            <Grid Grid.Row="1"
-                                  Grid.Column="0"
-                                  Grid.ColumnSpan="2"
-                                  Margin="0,10,0,10"
-                                  ColumnDefinitions="20,*,20,*,20,*">
-                                <!--#region Date-->
-                                <Label Grid.Column="0"
-                                       Style="{StaticResource ScheduleFontIcons}"
-                                       Text="{x:Static fonts:FontAwesomeIcons.CalendarDays}" />
-                                <Label Grid.Column="1"
-                                       Style="{StaticResource ScheduleFontIconsDesc}"
-                                       Text="{Binding AvailableTime, StringFormat='{0: M/dd/yyy}'}" />
-                                <!--#endregion-->
-
-                                <!--#region Time-->
-                                <Label Grid.Column="2"
-                                       Style="{StaticResource ScheduleFontIcons}"
-                                       Text="{x:Static fonts:FontAwesomeIcons.Clock}" />
-                                <Label Grid.Column="3"
-                                       Style="{StaticResource ScheduleFontIconsDesc}"
-                                       Text="{Binding AvailableTime.TimeOfDay}" />
-                                <!--#endregion-->
-
-                                <!--#region Booking Status-->
-                                <Ellipse Grid.Column="4"
-                                         Fill="#00DC54"
-                                         HeightRequest="10"
-                                         HorizontalOptions="Start"
-                                         VerticalOptions="Center"
-                                         WidthRequest="10">
-                                    <Ellipse.Triggers>
-                                        <DataTrigger Binding="{Binding BookingStatus}"
-                                                     TargetType="Ellipse"
-                                                     Value="{x:Static enums:BookingStatus.Pending}">
-                                            <Setter Property="Fill" Value="#FF8E00" />
-                                        </DataTrigger>
-                                        <DataTrigger Binding="{Binding BookingStatus}"
-                                                     TargetType="Ellipse"
-                                                     Value="{x:Static enums:BookingStatus.Cancelled}">
-                                            <Setter Property="Fill" Value="#E63C3C" />
-                                        </DataTrigger>
-                                    </Ellipse.Triggers>
-                                </Ellipse>
-                                <Label Grid.Column="5"
-                                       Style="{StaticResource ScheduleFontIconsDesc}"
-                                       Text="{Binding BookingStatus}" />
-                                <!--#endregion-->
-                            </Grid>
-                            <!--#endregion-->
-                            <Button Grid.Row="2"
-                                    Grid.Column="0"
-                                    Margin="5,0"
-                                    BackgroundColor="#F4F5F9"
-                                    Command="{Binding BindingContext.CancelScheduleCmd, Source={x:Reference this}}"
-                                    CommandParameter="{Binding .}"
-                                    CornerRadius="10"
-                                    FontFamily="med"
-                                    FontSize="12"
-                                    Text="Cancel"
-                                    TextColor="{StaticResource Black}" />
-
-                            <Button Grid.Row="2"
-                                    Grid.Column="1"
-                                    Margin="5,0"
-                                    BackgroundColor="{StaticResource DarkPurple}"
-                                    Command="{Binding BindingContext.RescheduleCmd, Source={x:Reference this}}"
-                                    CommandParameter="{Binding .}"
-                                    CornerRadius="10"
-                                    FontFamily="med"
-                                    FontSize="12"
-                                    Text="Reschedule"
-                                    TextColor="White" />
-                        </Grid>
-                    </Frame>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
         </CollectionView>
 
         <templates:ComboBox Grid.Row="2"

--- a/MedikTapp/Views/Welcome/Main/Schedule/ScheduleTabViewModel.cs
+++ b/MedikTapp/Views/Welcome/Main/Schedule/ScheduleTabViewModel.cs
@@ -3,6 +3,7 @@ using MedikTapp.Helpers.Command;
 using MedikTapp.Interfaces;
 using MedikTapp.Services.DatabaseService;
 using MedikTapp.Services.NavigationService;
+using MedikTapp.Services.NotificationService;
 using MedikTapp.ViewModels.Base;
 using Xamarin.Forms;
 
@@ -11,13 +12,16 @@ namespace MedikTapp.Views.Welcome.Main.Schedule
     public partial class ScheduleTabViewModel : TabItemPageViewModelBase
     {
         private readonly DatabaseService _databaseService;
+        private readonly NotificationService _notificationService;
         private readonly IToast _toast;
 
         public ScheduleTabViewModel(NavigationService navigationService,
             DatabaseService databaseService,
+            NotificationService notificationService,
             IToast toast) : base(navigationService)
         {
             _databaseService = databaseService;
+            _notificationService = notificationService;
             _toast = toast;
 
             ChangeFilterCmd = new AsyncSingleCommand<BookingSort>(ChangeFilter);

--- a/MedikTapp/Views/Welcome/Main/TimeAvailability/Methods.cs
+++ b/MedikTapp/Views/Welcome/Main/TimeAvailability/Methods.cs
@@ -4,6 +4,7 @@ using Plugin.LocalNotification.AndroidOption;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using Xamarin.Forms;
 
@@ -11,6 +12,7 @@ namespace MedikTapp.Views.Welcome.Main.TimeAvailability
 {
     public partial class TimeAvailabilityPopupViewModel
     {
+        private const int ClinicMaxHourCount = 17;
         private void RaiseSelectScheduleCanExecuteChanged() => SelectScheduleCmd.RaiseCanExecuteChanged();
 
         public override void Initialized(NavigationParameters parameters)
@@ -21,14 +23,19 @@ namespace MedikTapp.Views.Welcome.Main.TimeAvailability
             DisabledDates = GetDisabledDates();
             SelectedDate = _passedService.AvailableTime;
 
-            TimeCollection = new();
-            for (var index = 7; index < 17; index++)
+            if (DateTime.Now.Hour < 15)
             {
-                TimeCollection.Add(new()
+                var startAllowedTime = DateTime.Now.Hour + 2;
+                var allowedTimes = Enumerable.Range(startAllowedTime, ClinicMaxHourCount - startAllowedTime);
+                TimeCollection = new();
+                foreach (var time in allowedTimes)
                 {
-                    IsAvailable = true,
-                    Time = DateTime.Today.Add(new TimeSpan(index, 0, 0))
-                });
+                    TimeCollection.Add(new()
+                    {
+                        IsAvailable = true, //todo: check on backend first
+                        Time = DateTime.Today.Add(new TimeSpan(time, 0, 0))
+                    });
+                }
             }
         }
 
@@ -89,7 +96,7 @@ namespace MedikTapp.Views.Welcome.Main.TimeAvailability
         private List<DateTime> GetDisabledDates()
         {
             var disabledDates = new List<DateTime>();
-            for (var date = DateTime.Now; date <= new DateTime(2022, 12, 31); date = date.AddDays(1))
+            for (var date = DateTime.Now; date <= new DateTime(DateTime.Now.Year, 12, 31); date = date.AddDays(1))
             {
                 if (date.DayOfWeek == DayOfWeek.Sunday)
                     disabledDates.Add(date);

--- a/MedikTapp/Views/Welcome/Main/TimeAvailability/TimeAvailabilityPopup.xaml
+++ b/MedikTapp/Views/Welcome/Main/TimeAvailability/TimeAvailabilityPopup.xaml
@@ -69,6 +69,17 @@
                     <xct:EventToCommandBehavior Command="{Binding ChangeSelectedTimeCmd}"
                                                 EventName="SelectionChanged" />
                 </CollectionView.Behaviors>
+                <CollectionView.EmptyView>
+                    <Frame Padding="0"
+                           HasShadow="False"
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center">
+                        <Label FontFamily="med"
+                               HorizontalOptions="Center"
+                               Text="No available time"
+                               VerticalOptions="Center" />
+                    </Frame>
+                </CollectionView.EmptyView>
                 <CollectionView.ItemTemplate>
                     <DataTemplate x:DataType="model:TimeAvailability">
                         <Label FontFamily="med"


### PR DESCRIPTION
- Fixed service's width on schedule tab templates
- Adjusted disabled time selection prior to current time. Basically, the earliest appointment time will be two hours from the current time
- Fixed notification bug where a cancelled appointment will still send a notification to the user
- Added confirmation when cancelling an appointment
- Removed reschedule and cancel buttons on cancelled tab under schedule tab
- Added new validation that prevents the user from rescheduling/appointment cancelling three days or lower before the appointment date